### PR TITLE
Added ESP and AH with 96 bit HMAC

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,9 @@ THE SOFTWARE.
           "TCP": 20,
           "VXLAN": 50,
           "NVGRE": 42,
-          "STT": 54
+          "STT": 54,
+          "ESP with 96 bit HMAC": 38,
+          "AH with 96 bit HMAC": 24
       };
 
       function calculate_overhead()


### PR DESCRIPTION
**ESP**
[RFC4303](https://tools.ietf.org/html/rfc4303#section-2)

- SPI (4)
- Sequence (4)
- Payload data includes IV (16), we ignore the rest.
- Padding is ignored since we're interested in the maximum amount of data we can send, which means no padding (0)
- Pad length (1)
- Next header (1)
- Integrity check value seems to be (12) in most cases (like HMAC-MD5-96 and HMAC-SHA-1-96), but it's mentioned in the protocol name

Total: 38 bytes

**AH**
[RFC4302](https://tools.ietf.org/html/rfc4302#section-2)

- Next header (1)
- Payload length (1)
- Reserved (2)
- SPI (4)
- Sequence number (4)
- Integrity check value seems to be (12) in most cases (like HMAC-MD5-96 and HMAC-SHA-1-96), but it's mentioned in the protocol name

Total: 24 bytes