### PR TITLE
Added MACSec header

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,8 @@ THE SOFTWARE.
           "ESP (96 bit HMAC)": 38,
           "AH (96 bit HMAC)": 24,
           "L2TPv3": 8,
-          "WireGuard": 40
+          "WireGuard": 40,
+          "MACSec": 32
       };
 
       function calculate_overhead()


### PR DESCRIPTION
MACSec header is variable, but at most 32 bytes.